### PR TITLE
Added new method to allow the user to decide if they want to retrieve the profile or not

### DIFF
--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -124,6 +124,15 @@ public class MicrosoftAuthenticator {
         }
     }
 
+    /**
+     * Logs in a player using its Microsoft account credentials and retrieves its access and xboxUserHash
+     *
+     * @param email    Player Microsoft account e-mail
+     * @param password Player Microsoft account password
+     * @param retrieveProfile if you want to retrieve the minecraft profile
+     * @return The player's xbox profile with minecraft access token
+     * @throws MicrosoftAuthenticationException Thrown if one of the several HTTP requests failed at some point
+     */
     public MicrosoftAuthResult loginWithCredentials(String email, String password, boolean retrieveProfile) throws MicrosoftAuthenticationException {
         CookieHandler currentHandler = CookieHandler.getDefault();
         CookieHandler.setDefault(new CookieManager(null, CookiePolicy.ACCEPT_ALL));

--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -227,6 +227,27 @@ public class MicrosoftAuthenticator {
     }
 
     /**
+     * Logs in a player using a Microsoft account refresh token retrieved earlier.
+     *
+     * @param refreshToken Player Microsoft account refresh token
+     * @param retrieveProfile if you want to retrieve the minecraft profile
+     * @return The player's xbox profile with minecraft access token
+     * @throws MicrosoftAuthenticationException Thrown if one of the several HTTP requests failed at some point
+     */
+    public MicrosoftAuthResult loginWithRefreshToken(String refreshToken, boolean retrieveProfile) throws MicrosoftAuthenticationException {
+        Map<String, String> params = getLoginParams();
+        params.put("refresh_token", refreshToken);
+        params.put("grant_type", "refresh_token");
+
+        MicrosoftRefreshResponse response = http.postFormGetJson(
+                MICROSOFT_TOKEN_ENDPOINT,
+                params, MicrosoftRefreshResponse.class
+        );
+
+        return loginWithTokens(new AuthTokens(response.getAccessToken(), response.getRefreshToken()),retrieveProfile);
+    }
+
+    /**
      * Logs in a player using a Microsoft account tokens retrieved earlier.
      * <b>If the token was retrieved using Azure AAD/MSAL, it should be prefixed with d=</b>
      *


### PR DESCRIPTION
[contributing]: https://github.com/azura-client/OpenAuth/blob/master/.github/CONTRIBUTING.md

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [✓] I have checked the PRs for upcoming features/bug fixes.
- [✓] I have read the [contributing guidelines][contributing].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [✓ ] Internal code
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: NaN

## Description

These commits add a new function / method loginWithCredentials(String email, String password, boolean retrieveProfile)
this method can be used for minecraft accounts without a username set such as giftcards or gamepass accounts it returns the MicrosoftAuthResult with the MinecraftProfile set to null
